### PR TITLE
Updating instructions to CentOS installation

### DIFF
--- a/docs/part1/introduction.md
+++ b/docs/part1/introduction.md
@@ -54,10 +54,9 @@ sudo subscription-manager repos --enable rhel-7-server-extras-rpms
 sudo yum install ansible
 ```
 
-Caso você esteja usando CentOS 7 como **Máquina de Controle**, você precisa ativar o EPEL antes de instalar o Ansible Engine:
+Caso você esteja usando CentOS 7 como **Máquina de Controle**, basta executar:
 
 ```bash
-sudo yum install epel-release
 sudo yum install ansible
 ```
 


### PR DESCRIPTION
According to the last updated Ansible Docs, the ansible package transitioned from EPEL repository to the Extras channel, thus, making it unnecessary to add EPEL repo.

https://docs.ansible.com/ansible/latest/intro_installation.html